### PR TITLE
Autoshot v1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ bin
 rsrc.syso
 resource.syso
 *.syso
+autoshot.exe

--- a/KEYCODES.md
+++ b/KEYCODES.md
@@ -1,0 +1,160 @@
+# Key Code Reference
+
+This file documents the Windows virtual-key codes used by this project.
+
+## Project-Specific Keys
+
+| Use | Key | Virtual-Key Code |
+|-----|-----|------------------|
+| Auto-shot reconfigure | `F1` | `0x70` |
+| Auto-shot pause/resume | `F13` | `0x7C` |
+| Default auto-shot trigger | `Mouse 1` | `0x01` |
+
+## Mouse Buttons
+
+| Input | Virtual-Key Code |
+|-------|------------------|
+| Mouse 1 | `0x01` |
+| Mouse 2 | `0x02` |
+| Mouse 3 | `0x04` |
+| Mouse 4 | `0x05` |
+| Mouse 5 | `0x06` |
+
+## Keyboard Keys
+
+### Control Keys
+
+| Key | Virtual-Key Code |
+|-----|------------------|
+| Backspace | `0x08` |
+| Tab | `0x09` |
+| Enter | `0x0D` |
+| Pause | `0x13` |
+| Caps Lock | `0x14` |
+| Escape | `0x1B` |
+| Space | `0x20` |
+| Page Up | `0x21` |
+| Page Down | `0x22` |
+| End | `0x23` |
+| Home | `0x24` |
+| Left Arrow | `0x25` |
+| Up Arrow | `0x26` |
+| Right Arrow | `0x27` |
+| Down Arrow | `0x28` |
+| Insert | `0x2D` |
+| Delete | `0x2E` |
+
+### Number Keys
+
+| Key | Virtual-Key Code |
+|-----|------------------|
+| 0 | `0x30` |
+| 1 | `0x31` |
+| 2 | `0x32` |
+| 3 | `0x33` |
+| 4 | `0x34` |
+| 5 | `0x35` |
+| 6 | `0x36` |
+| 7 | `0x37` |
+| 8 | `0x38` |
+| 9 | `0x39` |
+
+### Letter Keys
+
+| Key | Virtual-Key Code |
+|-----|------------------|
+| A | `0x41` |
+| B | `0x42` |
+| C | `0x43` |
+| D | `0x44` |
+| E | `0x45` |
+| F | `0x46` |
+| G | `0x47` |
+| H | `0x48` |
+| I | `0x49` |
+| J | `0x4A` |
+| K | `0x4B` |
+| L | `0x4C` |
+| M | `0x4D` |
+| N | `0x4E` |
+| O | `0x4F` |
+| P | `0x50` |
+| Q | `0x51` |
+| R | `0x52` |
+| S | `0x53` |
+| T | `0x54` |
+| U | `0x55` |
+| V | `0x56` |
+| W | `0x57` |
+| X | `0x58` |
+| Y | `0x59` |
+| Z | `0x5A` |
+
+### Numpad Keys
+
+| Key | Virtual-Key Code |
+|-----|------------------|
+| Numpad 0 | `0x60` |
+| Numpad 1 | `0x61` |
+| Numpad 2 | `0x62` |
+| Numpad 3 | `0x63` |
+| Numpad 4 | `0x64` |
+| Numpad 5 | `0x65` |
+| Numpad 6 | `0x66` |
+| Numpad 7 | `0x67` |
+| Numpad 8 | `0x68` |
+| Numpad 9 | `0x69` |
+| Numpad * | `0x6A` |
+| Numpad + | `0x6B` |
+| Numpad - | `0x6D` |
+| Numpad . | `0x6E` |
+| Numpad / | `0x6F` |
+
+### Function Keys
+
+| Key | Virtual-Key Code |
+|-----|------------------|
+| F1 | `0x70` |
+| F2 | `0x71` |
+| F3 | `0x72` |
+| F4 | `0x73` |
+| F5 | `0x74` |
+| F6 | `0x75` |
+| F7 | `0x76` |
+| F8 | `0x77` |
+| F9 | `0x78` |
+| F10 | `0x79` |
+| F11 | `0x7A` |
+| F12 | `0x7B` |
+| F13 | `0x7C` |
+
+### Modifier Keys
+
+| Key | Virtual-Key Code |
+|-----|------------------|
+| Left Shift | `0xA0` |
+| Right Shift | `0xA1` |
+| Left Ctrl | `0xA2` |
+| Right Ctrl | `0xA3` |
+| Left Alt | `0xA4` |
+| Right Alt | `0xA5` |
+
+### Punctuation Keys
+
+| Key | Virtual-Key Code |
+|-----|------------------|
+| ; | `0xBA` |
+| = | `0xBB` |
+| , | `0xBC` |
+| - | `0xBD` |
+| . | `0xBE` |
+| / | `0xBF` |
+| ` | `0xC0` |
+| [ | `0xDB` |
+| \ | `0xDC` |
+| ] | `0xDD` |
+| ' | `0xDE` |
+
+## Notes
+
+- `KeyNames` and `MouseButtonNames` in `internal/keyboard/keyboard.go` is used as the selection map for the project.

--- a/README.md
+++ b/README.md
@@ -78,29 +78,36 @@ Level up your gameplay with smart automation. Three lightweight tools designed f
 
 ### Auto-Shot Setup
 
-This tool requires a quick one-time setup in your game settings:
+This tool requires a quick one-time setup in your game settings.
 
-#### Step 1: Change your in-game shoot key
+#### Step 1: Change your in-game primary firing key
 
-1. Open THE FINALS → **Settings** → **Keybinds**
-2. Change **"Fire"** from `Left Mouse Button` to any keyboard key (e.g., `L`)
+1. Open THE FINALS -> **Settings** -> **Keybinds**.
+2. Change **Primary Fire** from `Left Mouse Button` to any keyboard key (e.g., `L`)
 3. Apply and close settings
 
-#### Step 2: Configure the tool
+#### Step 2: First launch
 
 1. **Run** `thefinals-autoshot.exe`
-2. **Press** the same key you just mapped for shooting (e.g., `L`)
+2. **Press** the same keyboard key you mapped for **Primary Fire** in-game.
 3. The tool will confirm your selection
 
-#### Step 3: Play!
+#### Step 3: Optional reconfiguration
 
-- **Hold Left Mouse Button** to shoot — the tool rapidly presses your mapped key
-- Release to stop shooting
+- Pressing `F1` anytime resets the tool and enables you to reconfigure both the trigger key and the shooting key.
+- Press `F13` anytime to pause auto-shooting.
 
-| Action  | Key                      |
-|---------|--------------------------|
-| Trigger | Left Mouse Button (Hold) |
-| Shoot   | Your selected key        |
+#### Step 4: Play!
+
+- **Hold `Mouse 1`** or the trigger key you set shoot - the tool rapidly presses your mapped firing key
+- Release the trigger key to stop shooting
+
+| Action  | Key                  |
+|---------|----------------------|
+| Trigger | `Mouse 1` by default |
+| Shoot   | Your selected key    |
+| Rebind  | `F1`                 |
+| Pause   | `F13`                |
 
 > **Tip:** This works great with semi-auto weapons like pistols, revolvers, or burst weapons!
 

--- a/cmd/autoshot/main.go
+++ b/cmd/autoshot/main.go
@@ -5,6 +5,7 @@ import (
 
 	"os"
 	"os/signal"
+	"os/exec"
 	"syscall"
 	"time"
 
@@ -12,28 +13,105 @@ import (
 	"github.com/kkrav3ts/thefinals-autoping/internal/statistics"
 )
 
-func main() {
-	fmt.Println("THE FINALS Auto-Shooting Tool.")
+type autoShotConfig struct {
+	userFiringKey int
+	shotKey       int
+	delays        []time.Duration
+}
 
+func clearTerminal() {
+	cmd := exec.Command("cmd", "/c", "cls")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	_ = cmd.Run()
+}
+
+func configureAutoShot(debug bool, promptForTrigger bool, defaultTriggerKey int, delaysCount int, mean float64, stdDev float64, minVal float64, maxVal float64) autoShotConfig {
+	debugf := func(format string, args ...any) {
+		if !debug {
+			return
+		}
+		fmt.Printf("[DEBUG %s] %s\n", time.Now().Format("15:04:05.000"), fmt.Sprintf(format, args...))
+	}
+
+	fmt.Println("THE FINALS Auto-Shooting Tool.")
+	userFiringKey := defaultTriggerKey
+	if promptForTrigger {
+		fmt.Printf("Press the key or mouse button you want to use as the trigger for auto-shooting.\n")
+		debugf("Waiting for trigger key selection from %d configured inputs", len(keyboard.TriggerKeyNames))
+		userFiringKey = keyboard.DetectKeyPress(keyboard.TriggerKeyNames)
+		fmt.Printf("Auto-shoot trigger enabled using [%s] input.\n", keyboard.TriggerKeyNames[userFiringKey])
+		debugf("Selected trigger key: vk=0x%X name=%s", userFiringKey, keyboard.TriggerKeyNames[userFiringKey])
+		keyboard.WaitForKeyRelease(userFiringKey)
+	} else {
+		fmt.Printf("Auto-shoot trigger defaulted to [%s]. Press F1 to change it.\n", keyboard.TriggerKeyNames[userFiringKey])
+		debugf("Using default trigger key: vk=0x%X name=%s", userFiringKey, keyboard.TriggerKeyNames[userFiringKey])
+	}
+
+	fmt.Printf("Press the key you want to use for shooting.\n")
+	debugf("Waiting for shooting key selection from %d configured keys", len(keyboard.KeyNames))
+	shotKey := keyboard.DetectKeyPress(keyboard.KeyNames)
+	fmt.Printf("Auto-shooting enabled using [%s] key. Hold [%s] to simulate repeated clicks...\n", keyboard.KeyNames[shotKey], keyboard.TriggerKeyNames[userFiringKey])
+	debugf("Selected shot key: vk=0x%X name=%s", shotKey, keyboard.KeyNames[shotKey])
+	keyboard.WaitForKeyRelease(shotKey)
+	debugf("Delay generation config: count=%d mean=%.2fms stdDev=%.2fms min=%.2fms max=%.2fms", delaysCount, mean, stdDev, minVal, maxVal)
+
+	delays := statistics.GenerateClickDelays(delaysCount, mean, stdDev, minVal, maxVal)
+	fmt.Printf("Generated %v human-like key presses to be used in the loop.\n", delaysCount)
+
+	if debug && len(delays) > 0 {
+		minDelay := delays[0]
+		maxDelay := delays[0]
+		var total time.Duration
+		for _, delay := range delays {
+			if delay < minDelay {
+				minDelay = delay
+			}
+			if delay > maxDelay {
+				maxDelay = delay
+			}
+			total += delay
+		}
+		debugf("Delay pool summary: min=%v max=%v avg=%v", minDelay, maxDelay, total/time.Duration(len(delays)))
+		sampleCount := min(10, len(delays))
+		debugf("Delay pool sample (%d/%d): %v", sampleCount, len(delays), delays[:sampleCount])
+	}
+
+	fmt.Println("Close window or press Ctrl+C to exit")
+	fmt.Println("Press F1 to reconfigure trigger/shoot keys")
+	fmt.Println("Press F13 to pause/resume auto-shooting")
+
+	return autoShotConfig{
+		userFiringKey: userFiringKey,
+		shotKey:       shotKey,
+		delays:        delays,
+	}
+}
+
+func main() {
 	// PREDEFINED INPUTS
-	leftMouseButton := 0x01 // Virtual-Key Code for Left Mouse Button used as shooting key.
+	debug := false          // for debugging
+	userFiringKey := 0x01   // Trigger key held by the user to activate auto-shooting.
+	reconfigureKey := 0x70  // Virtual-Key Code for F1 used to restart setup.
+	pauseToggleKey := 0x7C  // Virtual-Key Code for F13 used to pause/resume the script.
 	delaysCount := 1000     // number of delays to generate
 	mean := 60.0            // midpoint of delay cluster
 	stdDev := 5.0           // standard deviation to create the delay cluster
 	minVal := 50.0          // minimum delay
 	maxVal := 80.0          // maximum delay
 
-	// USER-BASED INPUT
-	fmt.Printf("Press the key you want to use for shooting.\n")
-	shotKey := keyboard.DetectKeyPress(keyboard.KeyNames)
-	fmt.Printf("Auto-shooting enabled using [%s] key. Hold left mouse button to simulate repeated clicks...\n", keyboard.KeyNames[shotKey])
+	debugf := func(format string, args ...any) {
+		if !debug {
+			return
+		}
+		fmt.Printf("[DEBUG %s] %s\n", time.Now().Format("15:04:05.000"), fmt.Sprintf(format, args...))
+	}
 
-	// Generate a pool of delays to cycle through
-	delays := statistics.GenerateClickDelays(delaysCount, mean, stdDev, minVal, maxVal)
-	fmt.Printf("Generated %v human-like key presses to be used in the loop.\n", delaysCount)
+	config := configureAutoShot(debug, false, userFiringKey, delaysCount, mean, stdDev, minVal, maxVal)
+	userFiringKey = config.userFiringKey
+	shotKey := config.shotKey
+	delays := config.delays
 
-	// Graceful shutdown on Ctrl+C
-	fmt.Println("Close window or press Ctrl+C to exit")
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
 
@@ -45,14 +123,87 @@ func main() {
 
 	// Infinite loop for the main process
 	delayIndex := 0
+	shotCount := 0
+	paused := false
+	f1WasPressed := false
+	f13WasPressed := false
+	triggerWasPressed := false
+	lastShotStartedAt := time.Time{}
 	for {
-		if keyboard.IsKeyPressed(leftMouseButton) {
+		f1Pressed := keyboard.IsKeyPressed(reconfigureKey)
+		if f1Pressed && !f1WasPressed {
+			debugf("Reconfiguration requested with F1")
+			keyboard.WaitForKeyRelease(reconfigureKey)
+			clearTerminal()
+			config = configureAutoShot(debug, true, userFiringKey, delaysCount, mean, stdDev, minVal, maxVal)
+			userFiringKey = config.userFiringKey
+			shotKey = config.shotKey
+			delays = config.delays
+			delayIndex = 0
+			shotCount = 0
+			paused = false
+			triggerWasPressed = false
+			lastShotStartedAt = time.Time{}
+			f1WasPressed = false
+			f13WasPressed = false
+			continue
+		}
+		f1WasPressed = f1Pressed
+
+		f13Pressed := keyboard.IsKeyPressed(pauseToggleKey)
+		if f13Pressed && !f13WasPressed {
+			paused = !paused
+			if paused {
+				fmt.Println("Auto-shooting paused")
+				debugf("Pause toggled on with F13")
+			} else {
+				fmt.Println("Auto-shooting resumed")
+				debugf("Pause toggled off with F13")
+			}
+		}
+		f13WasPressed = f13Pressed
+
+		triggerPressed := keyboard.IsKeyPressed(userFiringKey)
+		if triggerPressed != triggerWasPressed {
+			if triggerPressed {
+				debugf("Trigger key pressed")
+			} else {
+				debugf("Trigger key released after %d simulated shots", shotCount)
+			}
+			triggerWasPressed = triggerPressed
+		}
+
+		if paused {
+			time.Sleep(10 * time.Millisecond)
+		} else if triggerPressed {
+			holdDelay := delays[delayIndex]
+
 			// Press key with human-like key pressed time
-			keyboard.PressKey(shotKey, delays[delayIndex])
+			pressStartedAt := time.Now()
+			keyboard.PressKey(shotKey, holdDelay)
+			pressElapsed := time.Since(pressStartedAt)
 			delayIndex = (delayIndex + 1) % len(delays)
 
 			// Human-like Delay between key pressed
-			time.Sleep(delays[delayIndex])
+			betweenDelay := delays[delayIndex]
+			sleepStartedAt := time.Now()
+			time.Sleep(betweenDelay)
+			sleepElapsed := time.Since(sleepStartedAt)
+			shotCount++
+			intervalSinceLastStart := time.Duration(0)
+			if !lastShotStartedAt.IsZero() {
+				intervalSinceLastStart = pressStartedAt.Sub(lastShotStartedAt)
+			}
+			lastShotStartedAt = pressStartedAt
+			debugf(
+				"Shot #%d hold=%v actualHold=%v gap=%v actualGap=%v sincePrevStart=%v",
+				shotCount,
+				holdDelay,
+				pressElapsed,
+				betweenDelay,
+				sleepElapsed,
+				intervalSinceLastStart,
+			)
 			delayIndex = (delayIndex + 1) % len(delays)
 		} else {
 			// Small polling delay to avoid excessive CPU usage when idle

--- a/internal/keyboard/keyboard.go
+++ b/internal/keyboard/keyboard.go
@@ -39,6 +39,27 @@ var KeyNames = map[int]string{
 	0xDB: "[", 0xDC: "\\", 0xDD: "]", 0xDE: "'",
 }
 
+// MouseButtonNames maps mouse virtual key codes to human-readable names.
+var MouseButtonNames = map[int]string{
+	0x01: "Mouse 1",
+	0x02: "Mouse 2",
+	0x04: "Mouse 3",
+	0x05: "Mouse 4",
+	0x06: "Mouse 5",
+}
+
+// TriggerKeyNames includes both keyboard keys and mouse buttons for trigger selection.
+var TriggerKeyNames = func() map[int]string {
+	keys := make(map[int]string, len(KeyNames)+len(MouseButtonNames))
+	for code, name := range KeyNames {
+		keys[code] = name
+	}
+	for code, name := range MouseButtonNames {
+		keys[code] = name
+	}
+	return keys
+}()
+
 // IsKeyPressed returns true if the specified virtual key is currently pressed.
 func IsKeyPressed(vk int) bool {
 	ret, _, _ := getAsyncKeyState.Call(uintptr(vk))
@@ -55,6 +76,13 @@ func DetectKeyPress(keysList map[int]string) int {
 				return k
 			}
 		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// WaitForKeyRelease blocks until the specified virtual key is no longer pressed. Is needed to prevent multiple detections of the same key when user holds assigns a trigger key.
+func WaitForKeyRelease(vk int) {
+	for IsKeyPressed(vk) {
 		time.Sleep(50 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
.gitignore
Added autoshot.exe to .gitignore

README.md
Rewrote some of the parts pertaining to autoshot to reflect the new changes.

cmd/autoshot/main.go
userFiringKey is now configurable instead of a hard-coded as left mouse. Selection of binds and keys now facilitates the use of mouse buttons. F1 now allows the user to configure and reconfigure both the bound keys. F13 now pauses the autoshooter.

internal/keyboard/keyboard.go
Added support for mouse buttons in the key code mapping. Added logic for 'WaitForKeyRelease'. This was necessary to allow for two keybinds to be set in succession after one another.

KEYCODES.md
Contains key code mappings for the keys supported by the project.